### PR TITLE
Add a new `base_config.yml` file we can use to test base_config

### DIFF
--- a/.expeditor/base_config.yml
+++ b/.expeditor/base_config.yml
@@ -1,0 +1,16 @@
+slack:
+  notify_channel:
+    - expeditor-testing
+    - expeditor-priv:
+        private: true
+
+pipelines:
+  - public-test:
+      organization: chef-oss
+      description: An empty pipeline to test communication with Buildkite
+      env:
+        - EXPEDITOR_CHANNEL: acceptance
+  - private-test:
+      description: An empty pipelint to test communication with Buildkite
+      env:
+        - EXPEDITOR_CHANNEL: acceptance


### PR DESCRIPTION
We add the file first so that Expeditor can find it when we formally
add it to the main config file.

Signed-off-by: Tom Duffield <tom@chef.io>