### PR TITLE
Updated config to not care about branch name for github release workload

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -46,7 +46,7 @@ subscriptions:
   - workload: buildkite_hab_build_group_published:{{agent_id}}:*
     actions:
       - built_in:promote_habitat_packages
-  - workload: github_release_published:{{agent_id}}:*
+  - workload: github_release_published:*
     actions:
       - bash:.expeditor/trigger_release_test.sh
 


### PR DESCRIPTION
Updated config to not care about branch name for github release workload
Signed-off-by: Nathaniel Kierpiec <nkierpiec@chef.io>